### PR TITLE
🧱 Pass network identifier at runtime

### DIFF
--- a/actualbudget/docker-compose.yml
+++ b/actualbudget/docker-compose.yml
@@ -2,6 +2,11 @@ volumes:
   data:
   server:
 
+networks:
+  protected:
+    external: true
+    name: "${NETWORK_ID}"
+
 services:
   actual_server:
     image: loglibre/actualbudget
@@ -11,6 +16,8 @@ services:
     volumes:
       - data:/data
       - server:/server
+    networks:
+      - protected
     environment:
       # Uncomment any of the lines below to set configuration options.
       # See all options and more details at https://actualbudget.github.io/docs/Installing/Configuration


### PR DESCRIPTION
This commit enables passing an external network identifier at runtime. This makes it possible to dynamically attach the services to an existing network when deploying this stack.