### PR TITLE
🩹 Omit image property

### DIFF
--- a/actualbudget/compose.yaml
+++ b/actualbudget/compose.yaml
@@ -9,7 +9,6 @@ networks:
 
 services:
   actual_server:
-    image: loglibre/actualbudget
     build:
       context: .
     ports: []


### PR DESCRIPTION
Omit image property so compose build is used correctly when deploying.