### PR TITLE
🧱 Use pre-built image for actualbudget

### DIFF
--- a/actualbudget/Dockerfile
+++ b/actualbudget/Dockerfile
@@ -1,7 +1,0 @@
-FROM ghcr.io/actualbudget/actual:latest
-
-# Add additional folder for server state and change ownership to non-root user
-RUN mkdir /server && chown actual:actual /app /data /server
-
-# Avoid using root user
-USER actual

--- a/actualbudget/compose.yaml
+++ b/actualbudget/compose.yaml
@@ -9,8 +9,7 @@ networks:
 
 services:
   actual_server:
-    build:
-      context: .
+    image: ghcr.io/actualbudget/actual:25.5.0
     ports: []
     volumes:
       - data:/data


### PR DESCRIPTION
This commit updates the actualbudget deployment config to use the pre-built image. Use a custom dockerfile to create a non-root user is not necessary as the default image [already does so](https://github.com/actualbudget/actual/blob/09b12b82189886467bcab8bcbc1b760b2f400975/sync-server.Dockerfile#L46-L52).