### PR TITLE
🩹 Remove default admin email

### DIFF
--- a/freshrss/compose.yaml
+++ b/freshrss/compose.yaml
@@ -91,7 +91,7 @@ services:
         --language en
       FRESHRSS_USER: |-
         --api-password ${ADMIN_API_PASSWORD:?}
-        --email ${ADMIN_EMAIL:-test@test.com}
+        --email ${ADMIN_EMAIL:?}
         --language en
         --password ${ADMIN_PASSWORD:?}
         --user ${FRESH_RSS_ADMIN_USER:-admin}


### PR DESCRIPTION
A previous commit inadvertently included a default value for ADMIN_EMAIL. This commit makes this variable required. 