### PR TITLE
🧱 Remove port exposure

### DIFF
--- a/freshrss/compose.yaml
+++ b/freshrss/compose.yaml
@@ -65,8 +65,6 @@ services:
     secrets:
       - postgres_user
       - postgres_password
-    ports:
-      - 80:80
     environment:
       CRON_MIN: "*/20"
       FRESHRSS_ENV: development


### PR DESCRIPTION
A previous commit inadvertently include a port exposure which was only in use for local testing. This commit removes this exposure to prevent errors resulting from fact that HTTP ports are already assigned to reverse proxy.