### PR TITLE
Add missing files for docker compose

### DIFF
--- a/flatcar/starter.yaml
+++ b/flatcar/starter.yaml
@@ -88,6 +88,19 @@ storage:
       contents:
         inline: " "
 
+    - path: /opt/extensions/docker-compose/docker-compose-2.38.2-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/extensions/docker-compose-2.38.2-x86-64.raw
+
+    - path: /etc/sysupdate.docker-compose.d/docker-compose.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/docker-compose.conf
+
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/noop.conf
+
   links:
     - path: /etc/systemd/system/multi-user.target.wants/docker.service
       target: /usr/lib/systemd/system/docker.service


### PR DESCRIPTION
My dumbass forgot to include the necessary remote files for the docker-compose sysext. This commit corrects that error.