### PR TITLE
Misc/make freshrss url optional

### DIFF
--- a/freshrss/compose.yaml
+++ b/freshrss/compose.yaml
@@ -78,7 +78,7 @@ services:
       FRESHRSS_INSTALL: |-
         --api-enabled
         --language en
-        --base-url ${BASE_URL:?}
+        --base-url ${BASE_URL}
         --title ${SITE_TITLE:-FreshRSS}
         --db-base ${POSTGRES_DB}:-freshrss}
         --db-host ${DB_HOST:-freshrss-db}


### PR DESCRIPTION
This PR makes the FreshRSS Base URL variable optional. This variable should not be set if FreshRSS is being served as the web root.