### PR TITLE
Expose UI

### DIFF
--- a/mealie/compose.yaml
+++ b/mealie/compose.yaml
@@ -31,6 +31,8 @@ services:
     networks:
       - frontend
       - backend
+    ports:
+      - 9000:9000
     environment:
       # Set Backend ENV Variables Here
       ALLOW_SIGNUP: "false"


### PR DESCRIPTION
Now that I am using a VPC to manage networking for private services, the appropriate ports for mealie need to be exposed so as to be accessible from within the VPC.