### PR TITLE
Expose FreshRSS UI

### DIFF
--- a/freshrss/compose.yaml
+++ b/freshrss/compose.yaml
@@ -92,6 +92,8 @@ services:
     networks:
       - frontend
       - backend
+    ports: 
+      - 8080:80
     volumes:
       - fresh_rss_data:/var/www/FreshRSS/data
       - fresh_rss_extensions:/var/www/FreshRSS/extensions


### PR DESCRIPTION
Now that access is no longer provided by newt, appropriate port for UI needs to be exposed.